### PR TITLE
Scope updating addresses to account

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcommerce/shift-node-api",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "src/index.js",
   "author": "Shift Commerce",
   "license": "ISC",

--- a/src/endpoints/account-endpoints.js
+++ b/src/endpoints/account-endpoints.js
@@ -48,8 +48,8 @@ function createAddressBookEntryV1 (body, customerAccountId) {
   return HTTPClient.post(`v1/customer_accounts/${customerAccountId}/addresses`, body)
 }
 
-function updateAddressV1 (body, addressId) {
-  return HTTPClient.patch(`v1/addresses/${addressId}`, body)
+function updateCustomerAddressV1 (body, addressId, customerAccountId) {
+  return HTTPClient.patch(`v1/customer_accounts/${customerAccountId}/addresses/${addressId}`, body)
 }
 
 function deleteAddressV1 (addressId, customerAccountId) {
@@ -85,5 +85,5 @@ module.exports = {
   createPasswordRecoveryV1,
   getCustomerAccountByTokenV1,
   updateCustomerAccountPasswordV1,
-  updateAddressV1
+  updateCustomerAddressV1
 }

--- a/src/shift-client.js
+++ b/src/shift-client.js
@@ -142,8 +142,8 @@ class SHIFTClient {
       .then(this.determineResponse)
   }
 
-  updateAddressV1 (body, addressId) {
-    return accountEndpoints.updateAddressV1(body, addressId)
+  updateCustomerAddressV1 (body, addressId, customerId) {
+    return accountEndpoints.updateCustomerAddressV1(body, addressId, customerId)
       .then(this.determineResponse)
   }
 

--- a/test/src/endpoints/account-endpoints.spec.js
+++ b/test/src/endpoints/account-endpoints.spec.js
@@ -9,7 +9,7 @@ const { getAccountV1,
   createPasswordRecoveryV1,
   getCustomerAccountByEmailV1,
   getCustomerAccountByTokenV1,
-  updateAddressV1
+  updateCustomerAddressV1
 } = require('../../../src/endpoints/account-endpoints')
 const nock = require('nock')
 const axios = require('axios')
@@ -582,7 +582,7 @@ describe('getCustomerAccountByTokenV1', () => {
   })
 })
 
-describe('updateAddressV1', () => {
+describe('updateCustomerAddressV1', () => {
   test("updates the address", () => {
     const addressData = {
       id: '10',
@@ -599,10 +599,10 @@ describe('updateAddressV1', () => {
     }
 
     nock(shiftApiConfig.get().apiHost)
-      .patch(`/${shiftApiConfig.get().apiTenant}/v1/addresses/77`, updatePayload)
+      .patch(`/${shiftApiConfig.get().apiTenant}/v1/customer_accounts/20/addresses/77`, updatePayload)
       .reply(200, addressData)
 
-    return updateAddressV1(updatePayload, 77)
+    return updateCustomerAddressV1(updatePayload, 77, 20)
       .then(response => {
         expect(response.status).toEqual(200)
         expect(response.data).toEqual(addressData)


### PR DESCRIPTION
### Overview

Related GitHub issue: https://github.com/shiftcommerce/shift-front-end-react/issues/839

Updates the `updateAddressV1` endpoint to use `v1/customer_accounts/{customer_id}/addresses/{address_id}` instead of `v1/addresses/{address_id}` and renames it to `updateCustomerAddressV1`.

This is so that we can ensure that customers can only update their own addresses.