### PR TITLE
Asset endpoints

### DIFF
--- a/src/endpoints/asset-endpoints.js
+++ b/src/endpoints/asset-endpoints.js
@@ -1,0 +1,93 @@
+const HTTPClient = require('../http-client')
+
+const bulkHeaders = {
+  'Content-Type': 'application/vnd.api+json; ext=bulk',
+  'Accept': 'application/vnd.api+json; ext=bulk'
+}
+
+/**
+ * Bulk add assets
+ *
+ * @param [{ name, reference, remote_file_url }] assets
+ */
+function createAssetsFilesV1 (assets) {
+  const data = assets.map(asset => {
+    return {
+      type: 'asset_files',
+      attributes: {
+        name: asset.name,
+        reference: asset.reference,
+        file_remote_url: asset.remote_file_url
+      },
+      relationships: {
+        asset_folder: {
+          type: 'asset_folders',
+          attributes: {
+            name: 'Product Imagery',
+            reference: 'product_imagery'
+          }
+        }
+      }
+    }
+  })
+
+  const payload = {
+    data: data,
+    meta: {
+      permissions: {
+        records: {
+          asset_files: [ 'create', 'update' ],
+          asset_folders: [ 'create', 'update' ]
+        }
+      }
+    }
+  }
+
+  return HTTPClient.post('v1/asset_files', payload, bulkHeaders).then(response => {
+    return {
+      status: response.status,
+      data: response.data
+    }
+  })
+}
+
+/**
+ * Bulk add mapping between asset files and products
+ *
+ * @param [{ product_reference, asset_file_reference }] req
+ */
+function createProductAssetFilesV1 (mappings) {
+  const data = mappings.map(mapping => {
+    return {
+      type: 'product_asset_files',
+      attributes: {
+        position: 0,
+        reference: 'join_' + mapping.product_reference + '_and_' + mapping.asset_file_reference,
+        product_reference: mapping.product_reference,
+        asset_file_reference: mapping.asset_file_reference
+      }
+    }
+  })
+
+  const payload = {
+    data: data,
+    meta: {
+      permissions: {
+        records: {
+          product_asset_files: [ 'create', 'update' ]
+        }
+      }
+    }
+  }
+  return HTTPClient.post('v1/product_asset_files', payload, bulkHeaders).then(response => {
+    return {
+      status: response.status,
+      data: response.data
+    }
+  })
+}
+
+module.exports = {
+  createAssetsFilesV1,
+  createProductAssetFilesV1
+}

--- a/src/endpoints/asset-endpoints.js
+++ b/src/endpoints/asset-endpoints.js
@@ -23,8 +23,8 @@ function createAssetsFilesV1 (assets) {
         asset_folder: {
           type: 'asset_folders',
           attributes: {
-            name: asset.folder ? asset.folder.name : 'Product Imagery',
-            reference: asset.folder ? asset.folder.reference : 'product_imagery'
+            name: asset.folder.name,
+            reference: asset.folder.reference
           }
         }
       }
@@ -61,7 +61,7 @@ function createProductAssetFilesV1 (mappings) {
     return {
       type: 'product_asset_files',
       attributes: {
-        position: mapping.position || 0,
+        position: mapping.position,
         reference: 'join_' + mapping.product_reference + '_and_' + mapping.asset_file_reference,
         product_reference: mapping.product_reference,
         asset_file_reference: mapping.asset_file_reference

--- a/src/endpoints/asset-endpoints.js
+++ b/src/endpoints/asset-endpoints.js
@@ -8,7 +8,7 @@ const bulkHeaders = {
 /**
  * Bulk add assets
  *
- * @param [{ name, reference, remote_file_url }] assets
+ * @param [{ name, reference, remote_file_url, asset_folder: { name, reference } }] assets
  */
 function createAssetsFilesV1 (assets) {
   const data = assets.map(asset => {
@@ -23,8 +23,8 @@ function createAssetsFilesV1 (assets) {
         asset_folder: {
           type: 'asset_folders',
           attributes: {
-            name: 'Product Imagery',
-            reference: 'product_imagery'
+            name: asset.folder ? asset.folder.name : 'Product Imagery',
+            reference: asset.folder ? asset.folder.reference : 'product_imagery'
           }
         }
       }
@@ -54,14 +54,14 @@ function createAssetsFilesV1 (assets) {
 /**
  * Bulk add mapping between asset files and products
  *
- * @param [{ product_reference, asset_file_reference }] req
+ * @param [{ product_reference, asset_file_reference, position }] req
  */
 function createProductAssetFilesV1 (mappings) {
   const data = mappings.map(mapping => {
     return {
       type: 'product_asset_files',
       attributes: {
-        position: 0,
+        position: mapping.position || 0,
         reference: 'join_' + mapping.product_reference + '_and_' + mapping.asset_file_reference,
         product_reference: mapping.product_reference,
         asset_file_reference: mapping.asset_file_reference

--- a/src/endpoints/import-endpoints.js
+++ b/src/endpoints/import-endpoints.js
@@ -1,0 +1,9 @@
+const HTTPClient = require('../http-client')
+
+function getImportV1 (id, query) {
+  return HTTPClient.get(`v1/imports/${id}`, query)
+}
+
+module.exports = {
+  getImportV1
+}

--- a/src/http-client.js
+++ b/src/http-client.js
@@ -2,20 +2,20 @@ const axios = require('axios')
 const qs = require('qs')
 const shiftApiConfig = require('./lib/config')
 
-const headers = {
+const defaultHeaders = {
   'Content-Type': 'application/vnd.api+json',
   'Accept': 'application/vnd.api+json'
 }
 
 class HTTPClient {
-  get (url, queryObject) {
+  get (url, queryObject, headers = {}) {
     const query = qs.stringify(queryObject)
     const requestUrl = this.createRequestUrl(url, query)
 
     const response = axios({
       method: 'get',
       url: requestUrl,
-      headers: headers,
+      headers: { ...defaultHeaders, ...headers },
       auth: {
         username: shiftApiConfig.get().apiTenant,
         password: shiftApiConfig.get().apiAccessToken
@@ -25,13 +25,13 @@ class HTTPClient {
     return this.determineResponse(response)
   }
 
-  post (url, body) {
+  post (url, body, headers = {}) {
     const requestUrl = this.createRequestUrl(url)
 
     const response = axios({
       method: 'post',
       url: requestUrl,
-      headers: headers,
+      headers: { ...defaultHeaders, ...headers },
       auth: {
         username: shiftApiConfig.get().apiTenant,
         password: shiftApiConfig.get().apiAccessToken
@@ -42,13 +42,13 @@ class HTTPClient {
     return this.determineResponse(response)
   }
 
-  patch (url, body) {
+  patch (url, body, headers = {}) {
     const requestUrl = this.createRequestUrl(url)
 
     const response = axios({
       method: 'patch',
       url: requestUrl,
-      headers: headers,
+      headers: { ...defaultHeaders, ...headers },
       auth: {
         username: shiftApiConfig.get().apiTenant,
         password: shiftApiConfig.get().apiAccessToken
@@ -59,13 +59,13 @@ class HTTPClient {
     return this.determineResponse(response)
   }
 
-  delete (url) {
+  delete (url, headers = {}) {
     const requestUrl = this.createRequestUrl(url)
 
     const response = axios({
       method: 'delete',
       url: requestUrl,
-      headers: headers,
+      headers: { ...defaultHeaders, ...headers },
       auth: {
         username: shiftApiConfig.get().apiTenant,
         password: shiftApiConfig.get().apiAccessToken

--- a/src/http-client.js
+++ b/src/http-client.js
@@ -99,7 +99,7 @@ class HTTPClient {
         return Promise.resolve({ status: response.status, data: response.data })
       })
       .catch(error => {
-        //console.log('Error is:', error)
+        console.log('Error is:', error)
         return Promise.reject(error)
       })
   }

--- a/src/http-client.js
+++ b/src/http-client.js
@@ -99,7 +99,7 @@ class HTTPClient {
         return Promise.resolve({ status: response.status, data: response.data })
       })
       .catch(error => {
-        console.log('Error is:', error)
+        //console.log('Error is:', error)
         return Promise.reject(error)
       })
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 module.exports = {
   SHIFTClient: require('./shift-client'),
-  shiftApiConfig: require('./lib/config')
+  shiftApiConfig: require('./lib/config'),
+  HTTPClient: require('./http-client')
 }

--- a/src/shift-client.js
+++ b/src/shift-client.js
@@ -9,6 +9,8 @@ const staticPageEndpoints = require('./endpoints/static-page-endpoints')
 const categoryEndpoints = require('./endpoints/category-endpoints')
 const accountEndpoints = require('./endpoints/account-endpoints')
 const orderEndpoints = require('./endpoints/order-endpoints')
+const assetEndpoints = require('./endpoints/asset-endpoints')
+const importEndpoints = require('./endpoints/import-endpoints')
 
 class SHIFTClient {
   getMenusV1 (query) {
@@ -174,6 +176,18 @@ class SHIFTClient {
   updateCustomerAccountPasswordV1 (accountId, body) {
     return accountEndpoints.updateCustomerAccountPasswordV1(accountId, body)
       .then(this.determineResponse)
+  }
+
+  createAssetsFilesV1 (assets) {
+    return assetEndpoints.createAssetsFilesV1(assets)
+  }
+
+  createProductAssetFilesV1 (mappings) {
+    return assetEndpoints.createProductAssetFilesV1(mappings)
+  }
+
+  getImport (id, query) {
+    return importEndpoints.getImportV1(id, query)
   }
 
   determineResponse (response) {

--- a/test/fixtures/create-assets-request.js
+++ b/test/fixtures/create-assets-request.js
@@ -1,0 +1,52 @@
+module.exports = {
+  data: [
+    {
+      type: 'asset_files',
+      attributes: {
+        name: 'foo',
+        reference: 'img_foo',
+        file_remote_url: 'http://example.com/some/path/to/a/file.jpg'
+      },
+      relationships: {
+        asset_folder: {
+          type: 'asset_folders',
+          attributes: {
+            name: 'Product Imagery',
+            reference: 'product_imagery'
+          }
+        }
+      }
+    },
+    {
+      type: 'asset_files',
+      attributes: {
+        name: 'foo2',
+        reference: 'img_foo2',
+        file_remote_url: 'http://example.com/some/path/to/a/different_file.jpg'
+      },
+      relationships: {
+        asset_folder: {
+          type: 'asset_folders',
+          attributes: {
+            name: 'Product Imagery',
+            reference: 'product_imagery'
+          }
+        }
+      }
+    }
+  ],
+  meta: {
+    permissions: {
+      records: {
+        asset_files: [
+          'create',
+          'update'
+        ],
+        asset_folders: [
+          'create',
+          'update'
+        ]
+      }
+    }
+  }
+}

--- a/test/fixtures/create-assets-request.js
+++ b/test/fixtures/create-assets-request.js
@@ -28,8 +28,8 @@ module.exports = {
         asset_folder: {
           type: 'asset_folders',
           attributes: {
-            name: 'Product Imagery',
-            reference: 'product_imagery'
+            name: 'somewhere',
+            reference: 'somereference'
           }
         }
       }

--- a/test/fixtures/create-assets-request.js
+++ b/test/fixtures/create-assets-request.js
@@ -11,8 +11,8 @@ module.exports = {
         asset_folder: {
           type: 'asset_folders',
           attributes: {
-            name: 'Product Imagery',
-            reference: 'product_imagery'
+            name: 'my folder',
+            reference: 'my_folder'
           }
         }
       }

--- a/test/fixtures/create-product-assets-request.js
+++ b/test/fixtures/create-product-assets-request.js
@@ -1,0 +1,43 @@
+module.exports = {
+  data: [
+    {
+      attributes: {
+        asset_file_reference: 'img_foo',
+        position: 0,
+        product_reference: 'foo',
+        reference: 'join_foo_and_img_foo'
+      },
+      type: 'product_asset_files'
+    },
+    {
+      attributes: {
+        asset_file_reference: 'img_bar',
+        position: 0,
+        product_reference: 'bar',
+        reference: 'join_bar_and_img_bar'
+      },
+      type: 'product_asset_files'
+    },
+    {
+      attributes: {
+        asset_file_reference: 'img_bar',
+        position: 0,
+        product_reference: 'foo',
+        reference: 'join_foo_and_img_bar'
+      },
+      type: 'product_asset_files'
+    },
+    {
+      attributes: {
+        asset_file_reference: 'img_bar2',
+        position: 0,
+        product_reference: 'bar',
+        reference: 'join_bar_and_img_bar2'
+      },
+      type: 'product_asset_files'
+    }
+  ],
+  meta: {
+    permissions: { records: { product_asset_files: ['create', 'update'] } }
+  }
+}

--- a/test/fixtures/create-product-assets-request.js
+++ b/test/fixtures/create-product-assets-request.js
@@ -21,7 +21,7 @@ module.exports = {
     {
       attributes: {
         asset_file_reference: 'img_bar',
-        position: 0,
+        position: 1,
         product_reference: 'foo',
         reference: 'join_foo_and_img_bar'
       },
@@ -30,7 +30,7 @@ module.exports = {
     {
       attributes: {
         asset_file_reference: 'img_bar2',
-        position: 0,
+        position: 1,
         product_reference: 'bar',
         reference: 'join_bar_and_img_bar2'
       },

--- a/test/fixtures/create-product-assets-request.js
+++ b/test/fixtures/create-product-assets-request.js
@@ -3,7 +3,7 @@ module.exports = {
     {
       attributes: {
         asset_file_reference: 'img_foo',
-        position: 0,
+        position: 5,
         product_reference: 'foo',
         reference: 'join_foo_and_img_foo'
       },

--- a/test/fixtures/import-response-payload.js
+++ b/test/fixtures/import-response-payload.js
@@ -1,0 +1,62 @@
+module.exports = {
+  data: {
+    id: '101',
+    type: 'imports',
+    links: {
+      self: '/trendygolf/v1/imports/101.json_api',
+      entries: '/trendygolf/v1/imports/101/import_entries.json_api',
+      processed_entries: '/trendygolf/v1/imports/101/import_entries.json_api?filter%5Bstatus%5D=success',
+      failed_entries: '/trendygolf/v1/imports/101/import_entries.json_api?filter%5Bstatus%5D=failed'
+    },
+    attributes: {
+      updated_at: '2019-05-01T12:52:04Z',
+      created_at: '2019-05-01T12:52:02Z',
+      status: 'processed',
+      importer_type: 'ProductAssetFiles',
+      processing_errors: [],
+      processed_entries: 1,
+      failed_entries: 0,
+      total_entries: 1
+    },
+    relationships: {
+      entries: {
+        links: {
+          self: '/trendygolf/v1/imports/101/relationships/entries.json_api',
+          related: '/trendygolf/v1/imports/101/entries.json_api'
+        }
+      },
+      import_entries: {
+        links: {
+          self: '/trendygolf/v1/imports/101/relationships/import_entries.json_api',
+          related: '/trendygolf/v1/imports/101/import_entries.json_api'
+        }
+      }
+    },
+    meta: {
+      status: 'processed',
+      importer_type: 'ProductAssetFiles',
+      processing_errors: [],
+      processed_entries: 1,
+      failed_entries: 0,
+      total_entries: 1,
+      created_at: '2019-05-01T12:52:02Z',
+      updated_at: '2019-05-01T12:52:04Z'
+    }
+  },
+  meta: {
+    status: 'processed',
+    importer_type: 'ProductAssetFiles',
+    processing_errors: [],
+    processed_entries: 1,
+    failed_entries: 0,
+    total_entries: 1,
+    created_at: '2019-05-01T12:52:02Z',
+    updated_at: '2019-05-01T12:52:04Z'
+  },
+  links: {
+    self: '/trendygolf/v1/imports/101.json_api',
+    entries: '/trendygolf/v1/imports/101/import_entries.json_api',
+    processed_entries: '/trendygolf/v1/imports/101/import_entries.json_api?filter%5Bstatus%5D=success',
+    failed_entries: '/trendygolf/v1/imports/101/import_entries.json_api?filter%5Bstatus%5D=failed'
+  }
+}

--- a/test/src/endpoints/asset-endpoints.spec.js
+++ b/test/src/endpoints/asset-endpoints.spec.js
@@ -1,0 +1,98 @@
+const { createAssetsFilesV1, createProductAssetFilesV1 } = require('../../../src/endpoints/asset-endpoints')
+const nock = require('nock')
+const axios = require('axios')
+const httpAdapter = require('axios/lib/adapters/http')
+const { shiftApiConfig } = require('../../../src/index')
+
+// Fixtures
+const newImportResponse = require('../../fixtures/import-response-payload') // functions under test return an import
+const createAssetsRequest = require('../../fixtures/create-assets-request')
+const createProductAssetsRequest = require('../../fixtures/create-product-assets-request')
+
+axios.defaults.adapter = httpAdapter
+
+beforeEach(() => {
+  shiftApiConfig.set({
+    apiHost: 'http://example.com',
+    apiTenant: 'test_tenant'
+  })
+})
+
+afterEach(() => {
+  nock.cleanAll()
+})
+
+describe('createAssetFilesV1', () => {
+  test('creates an import for a set of asset files', () => {
+    let request = {}
+
+    nock(shiftApiConfig.get().apiHost)
+      .post(`/${shiftApiConfig.get().apiTenant}/v1/asset_files`)
+      .query(true)
+      .reply(function (uri, requestBody) {
+        request = requestBody
+        return [ 201, newImportResponse ]
+      })
+
+    const assets = [
+      {
+        name: 'foo',
+        reference: 'img_foo',
+        remote_file_url: 'http://example.com/some/path/to/a/file.jpg'
+      },
+      {
+        name: 'foo2',
+        reference: 'img_foo2',
+        remote_file_url: 'http://example.com/some/path/to/a/different_file.jpg'
+      }
+    ]
+
+    return createAssetsFilesV1(assets)
+      .then(response => {
+        expect(JSON.parse(request)).toEqual(createAssetsRequest)
+        expect(response.status).toEqual(201)
+        expect(response.data).toEqual(newImportResponse)
+      })
+  })
+})
+
+describe('createProductAssetFiles', () => {
+  test('creates an import for a set of mappings between products and asset files', () => {
+    let request = {}
+
+    nock(shiftApiConfig.get().apiHost)
+      .post(`/${shiftApiConfig.get().apiTenant}/v1/product_asset_files`)
+      .query(true)
+      .reply(function (uri, requestBody) {
+        request = requestBody
+        return [ 201, newImportResponse ]
+      })
+
+    const mappings = [
+      {
+        product_reference: 'foo',
+        asset_file_reference: 'img_foo'
+      },
+      {
+        product_reference: 'bar',
+        asset_file_reference: 'img_bar'
+      },
+      {
+        product_reference: 'foo',
+        asset_file_reference: 'img_bar'
+      },
+      {
+        product_reference: 'bar',
+        asset_file_reference: 'img_bar2'
+      }
+    ]
+
+    return createProductAssetFilesV1(mappings)
+      .then(response => {
+        console.log(request)
+        expect(JSON.parse(request)).toEqual(createProductAssetsRequest)
+        expect(response.status).toEqual(201)
+        expect(response.data).toEqual(newImportResponse)
+      })
+  })
+})

--- a/test/src/endpoints/asset-endpoints.spec.js
+++ b/test/src/endpoints/asset-endpoints.spec.js
@@ -38,7 +38,11 @@ describe('createAssetFilesV1', () => {
       {
         name: 'foo',
         reference: 'img_foo',
-        remote_file_url: 'http://example.com/some/path/to/a/file.jpg'
+        remote_file_url: 'http://example.com/some/path/to/a/file.jpg',
+        folder: {
+          name: 'my folder',
+          reference: 'my_folder'
+        }
       },
       {
         name: 'foo2',
@@ -75,21 +79,24 @@ describe('createProductAssetFiles', () => {
       },
       {
         product_reference: 'bar',
-        asset_file_reference: 'img_bar'
+        asset_file_reference: 'img_bar',
+        position: 0
       },
       {
         product_reference: 'foo',
-        asset_file_reference: 'img_bar'
+        asset_file_reference: 'img_bar',
+        position: 1
+
       },
       {
         product_reference: 'bar',
-        asset_file_reference: 'img_bar2'
+        asset_file_reference: 'img_bar2',
+        position: 1
       }
     ]
 
     return createProductAssetFilesV1(mappings)
       .then(response => {
-        console.log(request)
         expect(JSON.parse(request)).toEqual(createProductAssetsRequest)
         expect(response.status).toEqual(201)
         expect(response.data).toEqual(newImportResponse)

--- a/test/src/endpoints/asset-endpoints.spec.js
+++ b/test/src/endpoints/asset-endpoints.spec.js
@@ -47,7 +47,11 @@ describe('createAssetFilesV1', () => {
       {
         name: 'foo2',
         reference: 'img_foo2',
-        remote_file_url: 'http://example.com/some/path/to/a/different_file.jpg'
+        remote_file_url: 'http://example.com/some/path/to/a/different_file.jpg',
+        folder: {
+          name: 'somewhere',
+          reference: 'somereference'
+        }
       }
     ]
 
@@ -75,7 +79,8 @@ describe('createProductAssetFiles', () => {
     const mappings = [
       {
         product_reference: 'foo',
-        asset_file_reference: 'img_foo'
+        asset_file_reference: 'img_foo',
+        position: 5
       },
       {
         product_reference: 'bar',

--- a/test/src/endpoints/import-endpoints.spec.js
+++ b/test/src/endpoints/import-endpoints.spec.js
@@ -1,0 +1,62 @@
+const { getImportV1 } = require('../../../src/endpoints/import-endpoints')
+const nock = require('nock')
+const axios = require('axios')
+const httpAdapter = require('axios/lib/adapters/http')
+const { shiftApiConfig } = require('../../../src/index')
+
+// Fixtures
+const importResponse = require('../../fixtures/import-response-payload')
+
+axios.defaults.adapter = httpAdapter
+
+beforeEach(() => {
+  shiftApiConfig.set({
+    apiHost: 'http://example.com',
+    apiTenant: 'test_tenant'
+  })
+})
+
+afterEach(() => { nock.cleanAll() })
+
+describe('getImportV1', () => {
+  test('returns an import when given a correct id', () => {
+    nock(shiftApiConfig.get().apiHost)
+      .get(`/${shiftApiConfig.get().apiTenant}/v1/imports/101`)
+      .reply(200, importResponse)
+
+    expect.assertions(2)
+
+    return getImportV1(101)
+      .then(response => {
+        expect(response.status).toEqual(200)
+        expect(response.data).toEqual(importResponse)
+      })
+  })
+
+  test('returns an error with incorrect id', () => {
+    nock(shiftApiConfig.get().apiHost)
+      .get(`/${shiftApiConfig.get().apiTenant}/v1/imports/102`)
+      .reply(404, {
+        'errors': [
+          {
+            'title': 'Record not found',
+            'detail': 'The record identified by 102 could not be found.',
+            'code': '404',
+            'status': '404'
+          }
+        ],
+        'meta': {
+          'facets': []
+        }
+      })
+
+    expect.assertions(2)
+
+    return getImportV1(102)
+      .catch(error => {
+        expect(error).toEqual(new Error('Request failed with status code 404'))
+        expect(error.response.data.errors[0].title).toEqual('Record not found')
+      })
+  })
+
+})

--- a/test/src/http-client.spec.js
+++ b/test/src/http-client.spec.js
@@ -51,7 +51,52 @@ describe('HTTPClient', () => {
 
       return expect(HTTPClient.get(url)).rejects.toEqual(new Error('Request failed with status code 404'))
     })
+
+    test('default headers are passed', async () => {
+      let headers = {}
+
+      // capture headers from any get request
+      nock(process.env.API_HOST).get(() => true).reply(function () { headers = this.req.headers })
+
+      await HTTPClient.get('someurl', {})
+
+      expect(headers).toMatchObject({
+        'content-type': 'application/vnd.api+json',
+        'accept': 'application/vnd.api+json'
+      })
+    })
+
+    test('default headers can be added to', async () => {
+      let headers = {}
+
+      // capture headers from any get request
+      nock(process.env.API_HOST).get(() => true).reply(function () { headers = this.req.headers })
+
+      await HTTPClient.get('someurl', {}, { 'x-dummy-header': 'somevalue' })
+
+      expect(headers).toMatchObject({
+        'content-type': 'application/vnd.api+json',
+        'accept': 'application/vnd.api+json',
+        'x-dummy-header': 'somevalue'
+      })
+    })
+
+    test('default headers can be overwritten', async () => {
+      let headers = {}
+
+      // capture headers from any get request
+      nock(process.env.API_HOST).get(() => true).reply(function () { headers = this.req.headers })
+
+      await HTTPClient.get('someurl', {}, { 'Accept': 'somevalue' })
+
+      expect(headers).toMatchObject({
+        'content-type': 'application/vnd.api+json',
+        'accept': 'somevalue'
+      })
+    })
+
   })
+
 
   describe('post', () => {
     test('saves and returns data', () => {
@@ -75,6 +120,50 @@ describe('HTTPClient', () => {
 
       return expect(HTTPClient.post(url, body)).resolves.toEqual({ status: 201, data: registerPayload })
     })
+
+    test('default headers are passed', async () => {
+      let headers = {}
+
+      // capture headers from any post request
+      nock(process.env.API_HOST).post(() => true).reply(function () { headers = this.req.headers })
+
+      await HTTPClient.post('someurl', '')
+
+      expect(headers).toMatchObject({
+        'content-type': 'application/vnd.api+json',
+        'accept': 'application/vnd.api+json'
+      })
+    })
+
+    test('default headers can be added to', async () => {
+      let headers = {}
+
+      // capture headers from any post request
+      nock(process.env.API_HOST).post(() => true).reply(function () { headers = this.req.headers })
+
+      await HTTPClient.post('someurl', '', { 'x-dummy-header': 'somevalue' })
+
+      expect(headers).toMatchObject({
+        'content-type': 'application/vnd.api+json',
+        'accept': 'application/vnd.api+json',
+        'x-dummy-header': 'somevalue'
+      })
+    })
+
+    test('default headers can be overwritten', async () => {
+      let headers = {}
+
+      // capture headers from any post request
+      nock(process.env.API_HOST).post(() => true).reply(function () { headers = this.req.headers })
+
+      await HTTPClient.post('someurl', '', { 'Accept': 'somevalue' })
+
+      expect(headers).toMatchObject({
+        'content-type': 'application/vnd.api+json',
+        'accept': 'somevalue'
+      })
+    })
+
   })
 
   describe('delete', () => {


### PR DESCRIPTION
### Overview

Related GitHub issue: shiftcommerce/matalan-integrations#102

- [x] Reviewed and filled in QA section
- [x] Reviewed and filled in Code Review section
- [x] Reviewed and filled in Dependencies review section
- [x] Documented development process in PR
- [x] Documented approach and thought process in issue

* Add some asset_files, product_asset_files and import endpoints needed for the Cloudinary integration Lambdas.  
* Added ability to override default headers to facilitate using the correct headers for bulk requests
* Exposed the HTTPClient in the package to make further development of integrations that use undocumented or otherwise shift-node-api unsupported Platform API endpoints more streamlined. (integrations can be developed against the whole API and support for uncovered endpoints backported into this library)   

### QA
I have written a local throwaway script that runs these endpoints with genuine credentials against the 'production' trendy tenant and confirmed they work as expected in the admin UI

### Code Review

**Documentation for Javascript files in JsDoc standard.**

* Describe the critical files for review here, if any.
* Any new concepts/patterns used should be included. Please create a wiki for it, and link it here. It would be easy to refer in future.
* List any new gems you've introduced – have they been reviewed by the team? If not, ask for consensus!

### Dependencies Review
No new dependencies
