### PR TITLE
change http client and shift client to pass through the headers from …

### DIFF
--- a/src/http-client.js
+++ b/src/http-client.js
@@ -104,7 +104,7 @@ class HTTPClient {
         })
       })
       .catch(error => {
-        //console.log('Error is:', error)
+        console.log('Error is:', error)
         return Promise.reject(error)
       })
   }

--- a/src/http-client.js
+++ b/src/http-client.js
@@ -1,6 +1,7 @@
 const axios = require('axios')
 const qs = require('qs')
 const shiftApiConfig = require('./lib/config')
+const { setCacheHeaders } = require('./lib/set-cache-headers')
 
 const defaultHeaders = {
   'Content-Type': 'application/vnd.api+json',
@@ -21,7 +22,6 @@ class HTTPClient {
         password: shiftApiConfig.get().apiAccessToken
       }
     })
-
     return this.determineResponse(response)
   }
 
@@ -96,10 +96,15 @@ class HTTPClient {
   determineResponse (response) {
     return response
       .then(response => {
-        return Promise.resolve({ status: response.status, data: response.data })
+        setCacheHeaders(response)
+        return Promise.resolve({
+          status: response.status,
+          data: response.data,
+          headers: response.headers
+        })
       })
       .catch(error => {
-        console.log('Error is:', error)
+        //console.log('Error is:', error)
         return Promise.reject(error)
       })
   }

--- a/src/lib/set-cache-headers.js
+++ b/src/lib/set-cache-headers.js
@@ -1,0 +1,28 @@
+// A function that sets CDN headers
+
+function setCacheHeaders (response) {
+  // fastly limit of 16,384 bytes is equal to 16384 utf-8 characters
+  const lengthLimit = 16384
+
+  if (response.headers['external-surrogate-key']) {
+    // extract surrogate keys
+    const externalSurrogateKeys = response.headers['external-surrogate-key'].split(' ').filter(uniq).join(' ')
+    const surrogateKeys = externalSurrogateKeys.split(' ').filter(word => !word.match('menu_item')).join(' ')
+
+    // set surrogate headers
+    response.headers['Surrogate-Key'] = surrogateKeys
+    response.headers['Surrogate-Control'] = 'max-age=3600,stale-if-error=86400,stale-while-revalidate=86400'
+
+    // print a warning when surrogate keys exceed limit
+    if (surrogateKeys.length > lengthLimit) {
+      console.log('Warning: The following Surrogate keys have exceeded the fastly length limit:', surrogateKeys)
+    }
+  }
+}
+
+// function to filter unique values
+function uniq (value, index, self) {
+  return self.indexOf(value) === index
+}
+
+module.exports = { setCacheHeaders }

--- a/src/shift-client.js
+++ b/src/shift-client.js
@@ -201,7 +201,8 @@ class SHIFTClient {
     const payload = parsedPayload || response.data
     return {
       status: response.status,
-      data: payload
+      data: payload,
+      headers: response.headers
     }
   }
 }

--- a/test/src/http-client.spec.js
+++ b/test/src/http-client.spec.js
@@ -28,7 +28,7 @@ describe('HTTPClient', () => {
         .get(`/${process.env.API_TENANT}/${url}`)
         .reply(200, staticPagePayload)
 
-      return expect(HTTPClient.get(url)).resolves.toEqual({ status: 200, data: staticPagePayload })
+      return expect(HTTPClient.get(url)).resolves.toEqual({ status: 200, data: staticPagePayload, headers: { 'content-type': 'application/json' } })
     })
 
     test('returns error data if a bad request', () => {
@@ -97,7 +97,6 @@ describe('HTTPClient', () => {
 
   })
 
-
   describe('post', () => {
     test('saves and returns data', () => {
       const url = 'v1/customer_accounts'
@@ -118,7 +117,8 @@ describe('HTTPClient', () => {
         .post(`/${process.env.API_TENANT}/${url}`)
         .reply(201, registerPayload)
 
-      return expect(HTTPClient.post(url, body)).resolves.toEqual({ status: 201, data: registerPayload })
+      const expected = { status: 201, data: registerPayload, headers: { 'content-type': 'application/json' } }
+      return expect(HTTPClient.post(url, body)).resolves.toEqual(expected)
     })
 
     test('default headers are passed', async () => {
@@ -176,7 +176,7 @@ describe('HTTPClient', () => {
         .reply(204)
 
       // Make the request
-      return expect(HTTPClient.delete(url)).resolves.toEqual({ data: '', status: 204 })
+      return expect(HTTPClient.delete(url)).resolves.toEqual({ data: '', status: 204, headers: {} })
     })
 
     test('correctly returns error responses and logs to console', () => {

--- a/test/src/lib/set-cache-headers.spec.js
+++ b/test/src/lib/set-cache-headers.spec.js
@@ -1,0 +1,34 @@
+const { setCacheHeaders } = require('../../../src/lib/set-cache-headers')
+describe('setCacheHeaders', () => {
+  test('Adds surrogate key header to the response', () => {
+    const response = { headers: { 'external-surrogate-key': 'key_1 key_2 key_3' } }
+
+    setCacheHeaders(response)
+
+    const result = {
+      headers: {
+        'external-surrogate-key': 'key_1 key_2 key_3',
+        'Surrogate-Key': 'key_1 key_2 key_3',
+        'Surrogate-Control': 'max-age=3600,stale-if-error=86400,stale-while-revalidate=86400'
+      }
+    }
+
+    expect(response).toEqual(result)
+  })
+
+  test('only adds unique values to surrogate key header', () => {
+    const response = { headers: { 'external-surrogate-key': 'key_1 key_2 key_2' } }
+
+    setCacheHeaders(response)
+
+    expect(response.headers['Surrogate-Key']).toEqual('key_1 key_2')
+  })
+
+  test('filters menu item keys from external-surrogate-key', () => {
+    const response = { headers: { 'external-surrogate-key': 'key_1 key_2 menu_item' } }
+
+    setCacheHeaders(response)
+
+    expect(response.headers['Surrogate-Key']).toEqual('key_1 key_2')
+  })
+})


### PR DESCRIPTION
…any platform request to the user and set the right Surrogate-* headers

### Overview

Related GitHub issue: shiftcommerce/trendy-golf#157

Change the responses back from shift-node-api to include the headers that were in the response from the platform.  This is so that we can inspect them later for cache control.

### QA
- [x] Ensure you've got all the unit tests covered for the issue. (Please add them if they are missing)
- [x] Verified for console errors (if any, please try to fix them. In case of complexity involved, please create an issue for them)
- [x] Checked for exception handling, in case of env keys missing (if introduced any, with this PR)

Affected area tests pass.  This branch preserves the existing broken test on master.  That should be dealt with in a separate PR
